### PR TITLE
Fix #3 : Change DIR from final_weights to final_weight

### DIFF
--- a/end-t-end-test/combine_test.py
+++ b/end-t-end-test/combine_test.py
@@ -26,7 +26,7 @@ half = device.type != 'cpu'
 print('device:', device)
 weights ='final_weight/detection_best.pt'
 model = attempt_load(weights, map_location=device)
-weights_reco ='recognition_model/final_weights/recognition_best.pt'
+weights_reco ='recognition_model/final_weight/recognition_best.pt'
 model_reco = attempt_load(weights_reco, map_location=device)
 #half=True
 if half:


### PR DESCRIPTION
Fix for FileNotFoundError: [Errno 2] No such file or directory: 'recognition_model/final_weights/recognition_best.pt'

Changeing
`weights_reco ='recognition_model/final_weights/recognition_best.pt'`
to
`weights_reco ='recognition_model/final_weight/recognition_best.pt'`

in ALPR-Yolov5/end-t-end-test/combine_test.py